### PR TITLE
Fix make-choice-item to properly support crux theme settings

### DIFF
--- a/lisp/sawfish/gtk/widget.jl
+++ b/lisp/sawfish/gtk/widget.jl
@@ -214,9 +214,13 @@
 	  ((set) (lambda (x)
 		   (gtk-combo-box-set-active combo (or (option-index options x) 0))))
 	  ((clear) nop)
-	  ((ref) (lambda () (if (numberp (nth (gtk-combo-box-get-active combo) options))
-			        (nth (gtk-combo-box-get-active combo) options)
-			      (string->symbol (symbol-name (nth (gtk-combo-box-get-active combo) options))))))
+	  ((ref) (lambda ()
+		   (let* ((option-idx (gtk-combo-box-get-active combo))
+			  (option (nth option-idx options))
+			  (selected (or (car option) option)))
+		     (if (numberp selected)
+			 selected
+		       (string->symbol (symbol-name selected))))))
 	  ((gtk-widget) combo)
 	  ((validp) (lambda (x) (option-index options x)))))))
 


### PR DESCRIPTION
In sawfish-config/appearance, if you select Crux, then try to modify the title bar buttons using Crux Theme page, changing the choice to any value causes an error, and the buttons stay the same.

This is caused by the particular choice type widget usage in Crux theme, where each choice option is a list containing a symbol and a string (instead of the usual symbol only usage in other pages). Since the page displays correctly, I thought the correct patch should be to fix the underlying code in widgets.jl for reading the value when a change event occurs.
