### PR TITLE
Interactive placement additions

### DIFF
--- a/lisp/sawfish/wm/placement.jl
+++ b/lisp/sawfish/wm/placement.jl
@@ -150,6 +150,7 @@ this mode. The single argument is the window to be placed."
   (define (place-window-interactively w)
     (require 'sawfish.wm.commands.move-resize)
     (let ((move-outline-mode 'box)
+	  (move-from-interactive-placement t)
 	  (ptr (query-pointer))
 	  (dims (window-frame-dimensions w)))
       ;; XXX hacktastic! I don't know why the next thing is needed,


### PR DESCRIPTION
Filter only ButtonRelease events before moving the 3x3 grid. Emacs for example, maps immediately if we ignore any event...

Mimic CTWM interactive placement features during the 3x3 grid move:
- clicking Button2 and dragging the outline will give the window its current position but allow the sides to be resized;
- clicking Button3 will give the window its current position but attempt to make it long enough to touch the bottom the screen;
- releasing any other button still position the window at the current position, as before.
