### PR TITLE
using NET_WM_ICON to get 16x16 icons

### DIFF
--- a/lisp/sawfish/wm/ext/cabinet.jl
+++ b/lisp/sawfish/wm/ext/cabinet.jl
@@ -396,8 +396,8 @@
            (t cabinet:default-item-forground))))
 
   (define (cabinet-item-format w)
-    (let ((item (cons (if (window-icon-image w)
-                          (window-icon-image w)
+    (let ((item (cons (if (window-icon-image w 32)
+                          (window-icon-image w 32)
                         (require 'rep.io.files)
                         (if (file-exists-p (concat (car (cdr image-load-path)) "/" "cabinet-missing.png"))
                             (make-image (concat (cdr image-load-path) "cabinet-missing.png"))))

--- a/lisp/sawfish/wm/util/display-wininfo.jl
+++ b/lisp/sawfish/wm/util/display-wininfo.jl
@@ -110,7 +110,7 @@ If W is nil previous window is removed."
 
     (when w
       (let* ((text (make-text-item (window-info w) default-font))
-	     (icon (let ((i (window-icon-image w)))
+	     (icon (let ((i (window-icon-image w 32)))
 		     (and i (scale-image i (car icon-size) (cdr icon-size)))))
 	     (icon-dims (if icon icon-size '(0 . 0)))
 	     (win-size (cons (+ (car icon-dims)

--- a/src/images.c
+++ b/src/images.c
@@ -95,7 +95,7 @@ load_image (char *file)
 
 /* Make a Lisp image object from the imlib image IM. Its initial properties
    will be taken from the list PLIST. */
-static repv
+repv
 make_image (image_t im, repv plist)
 {
     Lisp_Image *f;

--- a/src/images.c
+++ b/src/images.c
@@ -990,6 +990,49 @@ defines the color of its pixels.
     return Qnil;
 }
 
+#ifdef HAVE_GDK_PIXBUF
+static void
+argbdata_to_pixdata (gulong * argb_data, int len, unsigned char ** pixdata)
+{
+    guchar *p;
+    guint argb;
+    guint rgba;
+    int i;
+
+    *pixdata = rep_alloc (len * 4);
+    p = *pixdata;
+
+    i = 0;
+    while (i < len)
+    {
+        argb = argb_data[i];
+        rgba = (argb << 8) | (argb >> 24);
+
+        *p = rgba >> 24; ++p;
+        *p = (rgba >> 16) & 0xff; ++p;
+        *p = (rgba >> 8) & 0xff; ++p;
+        *p = rgba & 0xff; ++p;
+
+        ++i;
+    }
+}
+
+repv make_image_from_data (long * data, int size)
+{
+    unsigned char * pixdata;
+    argbdata_to_pixdata(data, size * size, &pixdata);
+
+    GdkPixbuf * img = gdk_pixbuf_new_from_data(pixdata,
+					       GDK_COLORSPACE_RGB,
+					       TRUE, 8,
+					       size, size,
+					       size * 4,
+					       free_pixbuf_data,
+					       pixdata);
+    return make_image(img, Qnil);
+}
+#endif
+
 DEFUN("tile-image", Ftile_image, Stile_image, (repv dst, repv src), rep_Subr2) /*
 ::doc:sawfish.wm.images#tile-image::
 tile-image DEST-IMAGE SOURCE-IMAGE

--- a/src/images.c
+++ b/src/images.c
@@ -95,7 +95,7 @@ load_image (char *file)
 
 /* Make a Lisp image object from the imlib image IM. Its initial properties
    will be taken from the list PLIST. */
-repv
+static repv
 make_image (image_t im, repv plist)
 {
     Lisp_Image *f;

--- a/src/sawfish.h
+++ b/src/sawfish.h
@@ -157,6 +157,7 @@ typedef struct lisp_window {
     repv net_name, net_icon_name;
     int frame_vis;
     repv icon_image;
+    int icon_size;
 
     /* Frame data */
     Window frame; /* Reparenter window */

--- a/src/sawfish_subrs.h
+++ b/src/sawfish_subrs.h
@@ -230,6 +230,7 @@ extern int image_channels (Lisp_Image *im);
 extern void image_changed (Lisp_Image *im);
 extern void images_init (void);
 extern void images_kill (void);
+extern repv make_image (image_t im, repv plist);
 
 /* from keys.c */
 extern repv Qglobal_keymap, Qunbound_key_hook, Qkeymap;

--- a/src/sawfish_subrs.h
+++ b/src/sawfish_subrs.h
@@ -230,7 +230,9 @@ extern int image_channels (Lisp_Image *im);
 extern void image_changed (Lisp_Image *im);
 extern void images_init (void);
 extern void images_kill (void);
-extern repv make_image (image_t im, repv plist);
+#ifdef HAVE_GDK_PIXBUF
+extern repv make_image_from_data (long * data, int size);
+#endif
 
 /* from keys.c */
 extern repv Qglobal_keymap, Qunbound_key_hook, Qkeymap;

--- a/src/windows.c
+++ b/src/windows.c
@@ -1403,34 +1403,6 @@ out:
     return tem;
 }
 
-#ifdef HAVE_GDK_PIXBUF
-static void
-argbdata_to_pixdata (gulong * argb_data, int len, guchar ** pixdata)
-{
-    guchar *p;
-    guint argb;
-    guint rgba;
-    int i;
-
-    *pixdata = g_new (guchar, len * 4);
-    p = *pixdata;
-
-    i = 0;
-    while (i < len)
-    {
-        argb = argb_data[i];
-        rgba = (argb << 8) | (argb >> 24);
-
-        *p = rgba >> 24; ++p;
-        *p = (rgba >> 16) & 0xff; ++p;
-        *p = (rgba >> 8) & 0xff; ++p;
-        *p = rgba & 0xff; ++p;
-
-        ++i;
-    }
-}
-#endif
-
 DEFUN("window-icon-image", Fwindow_icon_image,
       Swindow_icon_image, (repv args), rep_SubrN) /*
 ::doc:sawfish.wm.windows.subrs#window-icon-image::
@@ -1482,18 +1454,10 @@ WINDOW. Returns the symbol `nil' if no such image.
 	       for (i = 0; i < nitems; i += 2 + data.l[i] * data.l[i + 1])
 		   if (data.l[i] == iconsize && data.l[i + 1] == iconsize)
 		   {
-
-			iconsize = data.l[i];
-			guchar * pixdata;
-			argbdata_to_pixdata(&(data.l[i + 2]), iconsize * iconsize, &pixdata);
+			VWIN (win)->icon_image =
+				make_image_from_data(&(data.l[i + 2]), iconsize);
 			XFree (data.l);
-			GdkPixbuf * img = gdk_pixbuf_new_from_data(
-						pixdata,
-						GDK_COLORSPACE_RGB,
-						TRUE, 8,
-						iconsize, iconsize, iconsize * 4,
-						NULL, NULL);
-			return VWIN (win)->icon_image = make_image(img, Qnil);
+			return VWIN (win)->icon_image;
 		   }
 	   }
 	   if (data.l != 0)


### PR DESCRIPTION
Hi,
some sawfish themes use the window-icon-image function to get the icon displayed in top left corner of the window. However, for KDE apps the function returns 32x32 icon wich is then downscaled to 16x16 and that looks ugly.
So I added code that tries to get 16x16 icons using NET_WM_ICON property first. But then I noticed the cabinet uses that function too and would look better with bigger icons instead. So I added optional parameter to the function for requesting different size than the default 16x16.
It is implemented for GdkPixbuf only. I noticed building with imlib has been broken for a long time anyway (although a couple of ifdefs could fix that I guess). The argbdata_to_pixdata function is copied from xfwm4.

I am basically scratching my own itch with this, but if you find it useful, you can pull.
Oh and if you think there is a better solution please let me know.