### PR TITLE
Better detection of transient windows during tilings

### DIFF
--- a/lisp/sawfish/wm/tile/tiler.jl
+++ b/lisp/sawfish/wm/tile/tiler.jl
@@ -82,7 +82,7 @@
          (not (window-ignored-p w))
          (not (dock-window-p w))
          (not (tab-background-p w))
-         (eq (window-type w) 'default)))
+         (not (eq (window-type w) 'transient))))
 
   (define (tileable-windows #!optional ignore)
     (filter tileable-window-p (tileable-workspace-windows ignore)))

--- a/lisp/sawfish/wm/tile/utils.jl
+++ b/lisp/sawfish/wm/tile/utils.jl
@@ -55,7 +55,7 @@
                      ;; for pager and stuff
                      (not (window-visible-p w))
                      ;; no dialogs
-                     (not (eq (window-type w) 'default))
+                     (eq (window-type w) 'transient)
                      (tab-background-p w)
                      (window-ignored-p w)))
                (window-order current-workspace)))


### PR DESCRIPTION
We were avoiding tiling transient windows such as dialogs by including
in the tile-able window list only those windows of type 'default.  But
that excludes windows, such as CoreBird's, that are 'unframed.  With
this patch, we check for transients via the 'transient type.