### PR TITLE
avoid recreating theme tarballs

### DIFF
--- a/themes/Makefile.in
+++ b/themes/Makefile.in
@@ -46,12 +46,8 @@ all :
 install : all installdirs
 	for d in $(THEMES); do \
 	  rm -rf $(DESTDIR)$(themedir)/$$d; \
-	  for f in $(srcdir)/$$d/*; do \
-	    if [ $$f != $(srcdir)/$$d/CVS ]; then \
-	      ( cd $(srcdir) && LC_ALL=C GZIP=-9n tar czf $$d.tar.gz $$d/* ) ; \
-	      $(INSTALL_DATA) $$d.tar.gz $(DESTDIR)$(themedir)/$$d.tar.gz; \
-	    fi \
-	  done \
+	  ( cd $(srcdir) && LC_ALL=C tar -c $$d/* | gzip -n9 > $$d.tar.gz ) ; \
+	  $(INSTALL_DATA) $$d.tar.gz $(DESTDIR)$(themedir)/$$d.tar.gz; \
 	done
 	@# Don't use tar for StyleTab. It's not compression, but tar
 	@# itself slows in librep.


### PR DESCRIPTION
the old code was erroneously recreating theme tarballs for each file contained
thus calling tar over 200 times to create 8 tarballs

and nobody is using CVS anymore anyway

also use explicit gzip call instead of obsolescent GZIP env var