### PR TITLE
allow to override build time

### DIFF
--- a/build-info
+++ b/build-info
@@ -20,8 +20,18 @@ localedir="$5"
 sys_name="$HOSTNAME.$LOCALDOMAIN"
 user_name="$LOGNAME"
 
-build_date="`date +'%a %b %e %Y'`"
-build_time="`date +'%T %Z'`"
+dateopts=""
+if [ -n "$SOURCE_DATE_EPOCH" ] ; then
+    if date --version|grep -q GNU ; then
+        dateopts="-u -d @$SOURCE_DATE_EPOCH"
+    else
+        dateopts="-u -r $SOURCE_DATE_EPOCH"
+    fi
+    sys_name=reproducible
+    user_name=reproducible
+fi
+build_date="`date $dateopts +'%a %b %e %Y'`"
+build_time="`date $dateopts +'%T %Z'`"
 
 cat >src/build.h <<EOF
 /* build.h -- Definitions relating to the current build


### PR DESCRIPTION
and hostname and username
to allow for reproducible builds of sawfish packages.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This patch supports both GNU date and BSD date