### PR TITLE
Make theme tarball build reproducible

### DIFF
--- a/themes/Makefile.in
+++ b/themes/Makefile.in
@@ -39,7 +39,8 @@ THEMES := StyleTab absolute-e Crux microGUI mxflat Elberg-tabbed Zami-like candi
 
 all :
 	for d in $(THEMES); do \
-		( cd $(srcdir) && LC_ALL=C tar -c $$d/* | gzip -n9 > $$d.tar.gz ) ; \
+		( tar --help|grep -q sort= && rbopts=--sort=name ; \
+		  cd $(srcdir) && LC_ALL=C tar --format=gnu --mtime @1 $$rbopts -c $$d/* | gzip -n9 > $$d.tar.gz ) ; \
 	done
 
 install : all installdirs


### PR DESCRIPTION
See https://reproducible-builds.org/ for why this is good

sort is only needed for mxflat that includes subdirs

This assumes GNU tar is used and timestamp of files in the theme archives
are not important, so they are set to 1970-01-01.
Otherwise a more elaborate patch can be done.