### PR TITLE
match-window: allow specifying arbitrary functions as filter

### DIFF
--- a/man/sawfish.texi
+++ b/man/sawfish.texi
@@ -2748,11 +2748,15 @@ Let us see an example first:
                       (maximize . vertical)))
 @end lisp
 
-@var{rules} is an alist, and each value is matched using regex.
-Allowed keys are any of @code{WM_NAME}, @code{WM_CLASS},
+@var{rules} is an list where each element is a @code{(property
+. regex)} or a @code{(function . arguments)} cons.  In the first form,
+specified property is matched against the regular expression.  Allowed
+properties are any of @code{WM_NAME}, @code{WM_CLASS},
 @code{WM_ICON_NAME}, @code{WM_WINDOW_ROLE}, @code{WM_CLIENT_MACHINE},
-@code{WM_COMMAND}, and @code{WM_LOCALE_NAME}. Values to the keys are
-strings. Windows are selected if all of these rules match.
+@code{WM_COMMAND}, and @code{WM_LOCALE_NAME}.  In the second form,
+specified function is called with window as first argument and list of
+arguments specified in the cons as remaining arguments.  Windows are
+selected if all of these rules match.
 
 @var{actions} is an alist. For possible keys and values, see
 @file{lisp/sawfish/wm/ext/match-window.jl}.


### PR DESCRIPTION
Extend the ‘match-window-profile’ syntax such that specifying ‘(cons
FUNC ARGS)’ as a filter calls ‘(FUNC WND . ARGS)’ to filter windows
and profiles based on criteria different than just window properties.

For example, the following rule applies actions only to the first
terminal window:

    (define (my-first-terminal-p wnd)
      (let ((is-term (lambda (wnd)
                       (let ((cls (get-x-text-property wnd 'WM_CLASS)))
                         (and cls (string-equal "Term" (aref cls 0)))))))
        (and (is-term wnd)
             (do ((wnds (managed-windows) (cdr wnds)))
                 ((or (null wnds)
                      (and (not (eq (car wnds) wnd))
                           (is-term (car wnds))))
                  (null wnds))))))

    (add-window-matcher `((,my-first-terminal-p))
                        '((position . north-west)))