### PR TITLE
Restore support for Button9.

### DIFF
--- a/man/news.texi
+++ b/man/news.texi
@@ -96,6 +96,7 @@ see https://github.com/SawfishWM/sawfish/pull/49 [Mario Goulart]
 @item New or changes features
 @itemize @minus
 @item Make @code{match-window} allow specifying arbitrary functions as filter [Michal Nazarewicz]
+@item Add support for Button9 [Derek Upham]
 @end itemize
 
 @item Miscellaneous Changes

--- a/man/sawfish.1
+++ b/man/sawfish.1
@@ -31,7 +31,7 @@ Don't load rc or site-init files.
 .IP "\fB-q, \-\-quit\fP" 10
 Terminate the interpreter process.
 .IP "\fB-\-5-buttons\fP" 10
-Support keyboard layout switching, but drop mouse buttons 6 - 8 support.
+Support keyboard layout switching, but drop mouse buttons 6 and above.
 .IP "\fB-\-replace\fP" 10
 Replace the running window manager with Sawfish.
 .SS Display Options

--- a/src/keys.c
+++ b/src/keys.c
@@ -103,7 +103,7 @@ static unsigned int ev_mod_button_mask;
 static unsigned int state_mask;
 static int button_num;
 
-static int all_buttons[8] = { Button1, Button2, Button3, Button4, Button5, Button6, Button7, Button8 };
+static int all_buttons[9] = { Button1, Button2, Button3, Button4, Button5, Button6, Button7, Button8, Button9 };
 
 /*
   locks: currently LockMask, num_lock, and scroll_lock.
@@ -284,6 +284,9 @@ translate_event(unsigned long *code, unsigned long *mods, XEvent *xev)
 	case Button8:
 	    *mods |= Button8Mask;
 	    break;
+	case Button9:
+            *mods |= Button9Mask;
+            break;
 	}
 	ret = TRUE;
 	break;
@@ -364,6 +367,7 @@ translate_event_to_x_button (repv ev, unsigned int *button, unsigned int *state)
 	    { Button6, Button6Mask },
 	    { Button7, Button7Mask },
 	    { Button8, Button8Mask },
+	    { Button9, Button9Mask },
 	    { 0, 0 }
 	};
 	int i;
@@ -691,6 +695,7 @@ static struct key_def default_mods[] = {
     { "Button6",  Button6Mask },
     { "Button7",  Button7Mask },
     { "Button8",  Button8Mask },
+    { "Button9",  Button9Mask },
     { "Any",      EV_MOD_ANY },
     { "Release",  EV_MOD_RELEASE },
     { 0, 0 }
@@ -1884,13 +1889,13 @@ static void button_num_init(void){
 			  | Button4Mask | Button5Mask);
     state_mask = (1 << 13) - 1;
     {
-      /* delete Button6 - 8 entries from default_mods[] */
+      /* delete Button6 - Button9 entries from default_mods[] */
+      const char *button_strings[] = { "Button6", "Button7", "Button8", "Button9", NULL };
+
       int i, j = 0, k;
-      char str[10];
-      for ( i = 6; i <= 8; i++){
-	snprintf(str, 8, "Button%d", i);
+      for ( i = 0; i != NULL; i++){
 	for (j = 0; default_mods[j].name != 0; j++){
-	  if ( strncmp(default_mods[j].name, str, 8) == 0){
+	  if ( strcmp(default_mods[j].name, button_strings[i]) == 0){
 	    for( k = j; default_mods[k].name != 0; k++){
 	      default_mods[k] = default_mods[k + 1];
 	    }
@@ -1899,10 +1904,10 @@ static void button_num_init(void){
       }
     }
   }else{
-    button_num = 8;
+    button_num = sizeof(all_buttons)/sizeof(int);
     ev_mod_button_mask = (Button1Mask | Button2Mask | Button3Mask   \
 			  | Button4Mask | Button5Mask | Button6Mask \
-			  | Button7Mask | Button8Mask );
+			  | Button7Mask | Button8Mask | Button9Mask );
     state_mask = 0xffffffff;
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -477,7 +477,7 @@ where OPTIONS are any of:\n\
     --load FILE		load the file of Lisp forms called FILE\n\
     -l FILE\n\
 \n\
-    --5-buttons		ignore buttons 6 - 8 to enable kbd layout switching\n\
+    --5-buttons		recognize only buttons 1..5, to enable kbd layout switching\n\
     --version		print version details\n\
     --no-rc		don't load rc or site-init files\n\
     --quit, -q		terminate the interpreter process\n", prog_name);


### PR DESCRIPTION
This is the fix for the "revert" in
8b1c28809eee4d50c25fdd4cd0e4da7a46563556 eleven years ago (oof).

It looks like the specific choice of Button9Mask (1<<16) clobbered the
low-order event bit.  Even Button8Mask (1<<15) was bad, as it used the
same mask as X11's AnyModifier.

This commit does a couple of things:

1. Clean up the event type/mask enum.

   Put the button 6, 7, and 8 masks into the enum, where the reader
   can easily see how they relate to the others.

   Trim the masks, to precisely match the values that they cover.

   Document the three remaining bits, and why there are only three.

2. Clean up button_num_init():

   Eliminate the use of snprintf/strncmp to find buttons to remove.
   The new explicit list is safer, and someone searching for "Button9"
   (for example) to find edit locations will find this easily.

   Calculate the number of buttons based on compile-time data.
   This gets rid of a magic number value that might be easy to miss
   during updates.

3. Add button 9 throughout.